### PR TITLE
高速化テクニック

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -47,12 +47,15 @@ object HelloSBT extends JFXApp3 {
 
     val gaussianFilterButton: Button = new Button("gassian filter")
     gaussianFilterButton.setOnAction((_) -> {
+      val from = java.time.OffsetDateTime.now()
       val gaussianFilter = new GaussianFilter(3, 1.3)
       val out = gaussianFilter.filtering(image)
 
       val writableImageFiltered = new WritableImage(out.width, out.height)
       SwingFXUtils.toFXImage(out.image, writableImageFiltered)
       gc.drawImage(writableImageFiltered, 0, 0)
+      val to = java.time.OffsetDateTime.now()
+      println(to.toInstant.toEpochMilli - from.toInstant.toEpochMilli())
     })
 
     val biliearInterpolateButton: Button = new Button("bi-linear")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -47,15 +47,12 @@ object HelloSBT extends JFXApp3 {
 
     val gaussianFilterButton: Button = new Button("gassian filter")
     gaussianFilterButton.setOnAction((_) -> {
-      val from = java.time.OffsetDateTime.now()
       val gaussianFilter = new GaussianFilter(3, 1.3)
       val out = gaussianFilter.filtering(image)
 
       val writableImageFiltered = new WritableImage(out.width, out.height)
       SwingFXUtils.toFXImage(out.image, writableImageFiltered)
       gc.drawImage(writableImageFiltered, 0, 0)
-      val to = java.time.OffsetDateTime.now()
-      println(to.toInstant.toEpochMilli - from.toInstant.toEpochMilli())
     })
 
     val biliearInterpolateButton: Button = new Button("bi-linear")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -34,7 +34,7 @@ object HelloSBT extends JFXApp3 {
       case Success(src) => src
       case Failure(_)   => new BufferedImage(128, 128, TYPE_INT_ARGB)
     }
-    val origPixels: List[Pixel] = img.bufferedImageToPixels(bufImage)
+    val origPixels: Seq[Pixel] = img.bufferedImageToPixels(bufImage)
     val image: Image =
       new Image(origPixels, bufImage.getWidth, bufImage.getHeight)
 

--- a/src/main/scala/img/BilinearInterpolation.scala
+++ b/src/main/scala/img/BilinearInterpolation.scala
@@ -13,8 +13,8 @@ class BilinearInterpolation(rx: Double, ry: Double) {
     val aW: Int = (ax * srcWidth).toInt
 
     // output image
-    val interpolatedPixels: List[Pixel] =
-      for (y <- (0 until aH).toList; x <- (0 until aW).toList) yield {
+    val interpolatedPixels: Seq[Pixel] =
+      for (y <- (0 until aH); x <- (0 until aW)) yield {
         val yBefore = Math.min(Math.floor(y / ay).toInt, srcHeight - 2)
         val dy: Double = ((y / ay).toInt - yBefore).toDouble
 

--- a/src/main/scala/img/Image.scala
+++ b/src/main/scala/img/Image.scala
@@ -3,10 +3,10 @@ package img
 import java.awt.image.BufferedImage
 import java.awt.image.BufferedImage.TYPE_INT_ARGB
 
-class Image(pixs: List[Pixel], w: Int, h: Int) {
+class Image(pixs: Seq[Pixel], w: Int, h: Int) {
   val width: Int = w
   val height: Int = h
-  val pixels: List[Pixel] = pixs
+  val pixels: Seq[Pixel] = pixs
   val image = pixels2BufferedImage()
 
   def pixels2BufferedImage(): BufferedImage = {
@@ -26,8 +26,8 @@ class Image(pixs: List[Pixel], w: Int, h: Int) {
     require(width == that.width)
     require(height == that.height)
 
-    val sumPixels: List[Pixel] =
-      for (i <- (0 until width * height).toList)
+    val sumPixels: Seq[Pixel] =
+      for (i <- (0 until width * height))
         yield {
           val src = this.pixels(i)
           val dst = that.pixels(i)
@@ -41,8 +41,8 @@ class Image(pixs: List[Pixel], w: Int, h: Int) {
     require(width == that.width)
     require(height == that.height)
 
-    val diffPixels: List[Pixel] =
-      for (i <- (0 until width * height).toList)
+    val diffPixels: Seq[Pixel] =
+      for (i <- (0 until width * height))
         yield {
           val src = this.pixels(i)
           val dst = that.pixels(i)
@@ -53,7 +53,7 @@ class Image(pixs: List[Pixel], w: Int, h: Int) {
   }
 
   def scaling(scalar: Double): Image = {
-    val scaledPixels: List[Pixel] =
+    val scaledPixels: Seq[Pixel] =
       for (pix <- this.pixels)
         yield {
           pix.scaling(scalar)
@@ -63,18 +63,18 @@ class Image(pixs: List[Pixel], w: Int, h: Int) {
   }
 
   def grayScale(): Image = {
-    val grayscalePixels: List[Pixel] = for (pix <- pixels) yield pix.grayScale()
+    val grayscalePixels: Seq[Pixel] = for (pix <- pixels) yield pix.grayScale()
 
     new Image(grayscalePixels, width, height)
   }
 
   def normalize(): Image = {
     // red == green == blue if grayscale
-    val grayColorList: List[Double] = for (pix <- pixels) yield pix.red
+    val grayColorList: Seq[Double] = for (pix <- pixels) yield pix.red
 
     val maxGrayColor = grayColorList.max
 
-    val normalizedPixels: List[Pixel] =
+    val normalizedPixels: Seq[Pixel] =
       for (pix <- pixels)
         yield pix.normalize(maxGrayColor, maxGrayColor, maxGrayColor)
 
@@ -82,7 +82,7 @@ class Image(pixs: List[Pixel], w: Int, h: Int) {
   }
 
   def grayScale2Jet(): Image = {
-    val jetPixels: List[Pixel] =
+    val jetPixels: Seq[Pixel] =
       for (pix <- pixels) yield pix.grayscale2Jet(0.0, 1.0)
 
     new Image(jetPixels, width, height)

--- a/src/main/scala/img/filtering/Filter.scala
+++ b/src/main/scala/img/filtering/Filter.scala
@@ -62,7 +62,7 @@ class Filter(kSize: Int) {
           )
           .red
       )
-      .foldLeft(0.0)(_ + _)
+      .sum
 
     val sumG: Double = (0 until kernelSize * kernelSize)
       .map(idx =>
@@ -73,7 +73,7 @@ class Filter(kSize: Int) {
           )
           .green
       )
-      .foldLeft(0.0)(_ + _)
+      .sum
 
     val sumB: Double = (0 until kernelSize * kernelSize)
       .map(idx =>
@@ -84,7 +84,7 @@ class Filter(kSize: Int) {
           )
           .blue
       )
-      .foldLeft(0.0)(_ + _)
+      .sum
 
     Seq(sumR, sumG, sumB).map(c => clip(c, 0.0, 1.0))
   }

--- a/src/main/scala/img/filtering/Filter.scala
+++ b/src/main/scala/img/filtering/Filter.scala
@@ -6,9 +6,10 @@ import img.Pixel
 class Filter(kSize: Int) {
   val kernelSize: Int = kSize
   val paddingSize: Int = kernelSize / 2
+  val bufferRange = (0 until kernelSize * kernelSize)
 
   val kernel: Seq[Double] =
-    for (i <- (0 until kernelSize * kernelSize))
+    for (i <- bufferRange)
       yield 1.0 / (kernelSize * kernelSize)
 
   def filtering(src: Image): Image = {
@@ -53,7 +54,7 @@ class Filter(kSize: Int) {
       x: Int,
       y: Int
   ): Seq[Double] = {
-    val sumR: Double = (0 until kernelSize * kernelSize)
+    val sumR: Double = bufferRange
       .map(idx =>
         kernel(idx) * paddedImg
           .getPixel(
@@ -64,7 +65,7 @@ class Filter(kSize: Int) {
       )
       .sum
 
-    val sumG: Double = (0 until kernelSize * kernelSize)
+    val sumG: Double = bufferRange
       .map(idx =>
         kernel(idx) * paddedImg
           .getPixel(
@@ -75,7 +76,7 @@ class Filter(kSize: Int) {
       )
       .sum
 
-    val sumB: Double = (0 until kernelSize * kernelSize)
+    val sumB: Double = bufferRange
       .map(idx =>
         kernel(idx) * paddedImg
           .getPixel(

--- a/src/main/scala/img/filtering/Filter.scala
+++ b/src/main/scala/img/filtering/Filter.scala
@@ -3,22 +3,24 @@ package img.filtering
 import img.Image
 import img.Pixel
 
+import scala.collection.immutable.ArraySeq
+
 class Filter(kSize: Int) {
   val kernelSize: Int = kSize
   val paddingSize: Int = kernelSize / 2
-  val bufferRange = (0 until kernelSize * kernelSize)
+  val bufferRange = (0 until kernelSize * kernelSize).to(ArraySeq)
 
   val kernel: Seq[Double] =
-    for (i <- bufferRange)
-      yield 1.0 / (kernelSize * kernelSize)
+    (for (i <- bufferRange)
+      yield 1.0 / (kernelSize * kernelSize)).to(ArraySeq)
 
   def filtering(src: Image): Image = {
     val paddedImg: Image = padding(src)
 
-    val filteredPixels: Seq[Pixel] =
+    val filteredPixels: ArraySeq[Pixel] =
       for (
-        y <- (0 until paddedImg.height);
-        x <- (0 until paddedImg.width)
+        y <- (0 until paddedImg.height).to(ArraySeq);
+        x <- (0 until paddedImg.width).to(ArraySeq)
       ) yield {
         if (
           y < paddingSize || y > src.height + paddingSize - 1 || x < paddingSize || x > src.width + paddingSize - 1
@@ -95,9 +97,7 @@ class Filter(kSize: Int) {
     val paddedHeight = src.height + 2 * paddingSize
 
     val paddedPixels =
-      for (
-        y <- (0 until paddedHeight); x <- (0 until paddedWidth)
-      )
+      for (y <- (0 until paddedHeight); x <- (0 until paddedWidth))
         yield {
           if (
             y < paddingSize || y > src.height + paddingSize - 1 || x < paddingSize || x > src.width + paddingSize - 1

--- a/src/main/scala/img/filtering/Filter.scala
+++ b/src/main/scala/img/filtering/Filter.scala
@@ -7,17 +7,17 @@ class Filter(kSize: Int) {
   val kernelSize: Int = kSize
   val paddingSize: Int = kernelSize / 2
 
-  val kernel: List[Double] =
-    for (i <- (0 until kernelSize * kernelSize).toList)
+  val kernel: Seq[Double] =
+    for (i <- (0 until kernelSize * kernelSize))
       yield 1.0 / (kernelSize * kernelSize)
 
   def filtering(src: Image): Image = {
     val paddedImg: Image = padding(src)
 
-    val filteredPixels: List[Pixel] =
+    val filteredPixels: Seq[Pixel] =
       for (
-        y <- (0 until paddedImg.height).toList;
-        x <- (0 until paddedImg.width).toList
+        y <- (0 until paddedImg.height);
+        x <- (0 until paddedImg.width)
       ) yield {
         if (
           y < paddingSize || y > src.height + paddingSize - 1 || x < paddingSize || x > src.width + paddingSize - 1
@@ -48,12 +48,12 @@ class Filter(kSize: Int) {
   }
 
   def fold(
-      kernel: List[Double],
+      kernel: Seq[Double],
       paddedImg: Image,
       x: Int,
       y: Int
-  ): List[Double] = {
-    val sumR: Double = (0 until kernelSize * kernelSize).toList
+  ): Seq[Double] = {
+    val sumR: Double = (0 until kernelSize * kernelSize)
       .map(idx =>
         kernel(idx) * paddedImg
           .getPixel(
@@ -64,7 +64,7 @@ class Filter(kSize: Int) {
       )
       .foldLeft(0.0)(_ + _)
 
-    val sumG: Double = (0 until kernelSize * kernelSize).toList
+    val sumG: Double = (0 until kernelSize * kernelSize)
       .map(idx =>
         kernel(idx) * paddedImg
           .getPixel(
@@ -75,7 +75,7 @@ class Filter(kSize: Int) {
       )
       .foldLeft(0.0)(_ + _)
 
-    val sumB: Double = (0 until kernelSize * kernelSize).toList
+    val sumB: Double = (0 until kernelSize * kernelSize)
       .map(idx =>
         kernel(idx) * paddedImg
           .getPixel(
@@ -86,7 +86,7 @@ class Filter(kSize: Int) {
       )
       .foldLeft(0.0)(_ + _)
 
-    List(sumR, sumG, sumB).map(c => clip(c, 0.0, 1.0))
+    Seq(sumR, sumG, sumB).map(c => clip(c, 0.0, 1.0))
   }
 
   def padding(src: Image): Image = {
@@ -95,7 +95,7 @@ class Filter(kSize: Int) {
 
     val paddedPixels =
       for (
-        y <- (0 until paddedHeight).toList; x <- (0 until paddedWidth).toList
+        y <- (0 until paddedHeight); x <- (0 until paddedWidth)
       )
         yield {
           if (
@@ -121,8 +121,8 @@ class Filter(kSize: Int) {
 
     val unpaddedPixels =
       for (
-        y <- (paddingSize until src.height - paddingSize).toList;
-        x <- (paddingSize until src.width - paddingSize).toList
+        y <- (paddingSize until src.height - paddingSize);
+        x <- (paddingSize until src.width - paddingSize)
       )
         yield {
           new Pixel(

--- a/src/main/scala/img/filtering/GaborFilter.scala
+++ b/src/main/scala/img/filtering/GaborFilter.scala
@@ -1,6 +1,7 @@
 package img.filtering
 
 import img._
+import scala.collection.immutable.ArraySeq
 
 class GaborFilter(
     ksize: Int,
@@ -16,7 +17,7 @@ class GaborFilter(
   val psi = _psi
   val angle = _angle
 
-  override val kernel: Seq[Double] = calcGabor
+  override val kernel: Seq[Double] = calcGabor.to(ArraySeq)
 
   private def calcGabor: Seq[Double] = {
     val gaborResult: Seq[Double] =

--- a/src/main/scala/img/filtering/GaborFilter.scala
+++ b/src/main/scala/img/filtering/GaborFilter.scala
@@ -16,11 +16,11 @@ class GaborFilter(
   val psi = _psi
   val angle = _angle
 
-  override val kernel: List[Double] = calcGabor
+  override val kernel: Seq[Double] = calcGabor
 
-  private def calcGabor: List[Double] = {
-    val gaborResult: List[Double] =
-      for (y <- (0 until kernelSize).toList; x <- (0 until kernelSize).toList)
+  private def calcGabor: Seq[Double] = {
+    val gaborResult: Seq[Double] =
+      for (y <- (0 until kernelSize); x <- (0 until kernelSize))
         yield {
           val px = x - paddingSize
           val py = y - paddingSize
@@ -45,8 +45,8 @@ class GaborFilter(
 
   def kernelToImage: Image = {
     val standardKernel = kernel.map(x => x - kernel.min)
-    val kernelToPixels: List[Pixel] =
-      for (i <- (0 until kernelSize * kernelSize).toList) yield {
+    val kernelToPixels: Seq[Pixel] =
+      for (i <- (0 until kernelSize * kernelSize)) yield {
         val x = i % kernelSize
         val y = i / kernelSize
 

--- a/src/main/scala/img/filtering/GaussianFilter.scala
+++ b/src/main/scala/img/filtering/GaussianFilter.scala
@@ -1,6 +1,7 @@
 package img.filtering
 
 import java.lang.Math
+import scala.collection.immutable.ArraySeq
 
 class GaussianFilter(kSize: Int, sigma: Double) extends Filter(kSize) {
   override val kernel: Seq[Double] = {
@@ -10,5 +11,5 @@ class GaussianFilter(kSize: Int, sigma: Double) extends Filter(kSize) {
           -((x - paddingSize) * (x - paddingSize) + (y - paddingSize) * (y - paddingSize))
         ) / (2.0 * sigma * sigma)
       }
-  }
+  }.to(ArraySeq)
 }

--- a/src/main/scala/img/filtering/GaussianFilter.scala
+++ b/src/main/scala/img/filtering/GaussianFilter.scala
@@ -3,8 +3,8 @@ package img.filtering
 import java.lang.Math
 
 class GaussianFilter(kSize: Int, sigma: Double) extends Filter(kSize) {
-  override val kernel: List[Double] = {
-    for (y <- (0 until kernelSize).toList; x <- (0 until kernelSize).toList)
+  override val kernel: Seq[Double] = {
+    for (y <- (0 until kernelSize); x <- (0 until kernelSize))
       yield {
         Math.exp(
           -((x - paddingSize) * (x - paddingSize) + (y - paddingSize) * (y - paddingSize))

--- a/src/main/scala/img/package.scala
+++ b/src/main/scala/img/package.scala
@@ -12,11 +12,11 @@ package object img {
     Try(ImageIO.read(file))
   }
 
-  def bufferedImageToPixels(src: BufferedImage): List[Pixel] = {
+  def bufferedImageToPixels(src: BufferedImage): Seq[Pixel] = {
     val width: Int = src.getWidth
     val height: Int = src.getHeight
 
-    for (iter <- (0 until width * height).toList) yield {
+    for (iter <- (0 until width * height)) yield {
       val x = iter % width
       val y = iter / height
       val color = src.getRGB(x, y)

--- a/src/main/scala/img/saliencyMap/SaliencyMap.scala
+++ b/src/main/scala/img/saliencyMap/SaliencyMap.scala
@@ -7,8 +7,8 @@ import img.BilinearInterpolation
 class SaliencyMap() {
   val gaussianFilter = new GaussianFilter(3, 1.3)
 
-  def makePyramid(orig: Image): List[Image] = {
-    val pyramid: List[Image] = for (i <- (1 to 6).toList) yield {
+  def makePyramid(orig: Image): Seq[Image] = {
+    val pyramid: Seq[Image] = for (i <- (1 to 6)) yield {
       val upScale: Double = Math.pow(2, i).toDouble
       val downScale: Double = 1 / upScale
       val downScaleInterpolation =
@@ -23,7 +23,7 @@ class SaliencyMap() {
       upScaledImage
     }
 
-    orig :: pyramid
+    orig +: pyramid
   }
 
   def saliencyMap(orig: Image): Image = {

--- a/src/main/scala/img/saliencyMap/ittiSaliencyMap.scala
+++ b/src/main/scala/img/saliencyMap/ittiSaliencyMap.scala
@@ -5,7 +5,7 @@ import _root_.img.filtering.GaborFilter
 
 class ittiSaliencyMap() extends SaliencyMap() {
   def calcRImage(src: Image): Image = {
-    val rPixels: List[Pixel] = for (pixel <- src.pixels) yield {
+    val rPixels: Seq[Pixel] = for (pixel <- src.pixels) yield {
       val tmpValue = pixel.red - (pixel.green + pixel.blue) / 2
       val newValue = Math.max(tmpValue, 0.0)
       val newColor =
@@ -18,7 +18,7 @@ class ittiSaliencyMap() extends SaliencyMap() {
   }
 
   def calcGImage(src: Image): Image = {
-    val gPixels: List[Pixel] = for (pixel <- src.pixels) yield {
+    val gPixels: Seq[Pixel] = for (pixel <- src.pixels) yield {
       val tmpValue = pixel.green - (pixel.red + pixel.blue) / 2
       val newValue = Math.max(tmpValue, 0.0)
       val newColor =
@@ -31,7 +31,7 @@ class ittiSaliencyMap() extends SaliencyMap() {
   }
 
   def calcBImage(src: Image): Image = {
-    val bPixels: List[Pixel] = for (pixel <- src.pixels) yield {
+    val bPixels: Seq[Pixel] = for (pixel <- src.pixels) yield {
       val tmpValue = pixel.blue - (pixel.red + pixel.green) / 2
       val newValue = Math.max(tmpValue, 0.0)
       val newColor =
@@ -44,7 +44,7 @@ class ittiSaliencyMap() extends SaliencyMap() {
   }
 
   def calcYImage(src: Image): Image = {
-    val yPixels: List[Pixel] = for (pixel <- src.pixels) yield {
+    val yPixels: Seq[Pixel] = for (pixel <- src.pixels) yield {
       val tmpValue = (pixel.red + pixel.green) / 2 - Math.abs(
         pixel.red - pixel.green
       ) / 2 - pixel.blue
@@ -84,8 +84,8 @@ class ittiSaliencyMap() extends SaliencyMap() {
     (rgMap, byMap)
   }
 
-  def makeIntensityPyramid(orig: Image): List[Image] = {
-    val pyramid: List[Image] = for (i <- (1 to 6).toList) yield {
+  def makeIntensityPyramid(orig: Image): Seq[Image] = {
+    val pyramid: Seq[Image] = for (i <- (1 to 6)) yield {
       val upScale: Double = Math.pow(2, i).toDouble
       val downScale: Double = 1 / upScale
       val downScaleInterpolation =
@@ -100,7 +100,7 @@ class ittiSaliencyMap() extends SaliencyMap() {
       upScaledImage
     }
 
-    orig :: pyramid
+    orig +: pyramid
   }
 
   def calcIntensitySaliencyMap(src: Image): Image = {

--- a/src/main/scala/img/saliencyMap/ittiSaliencyMap.scala
+++ b/src/main/scala/img/saliencyMap/ittiSaliencyMap.scala
@@ -115,46 +115,56 @@ class ittiSaliencyMap() extends SaliencyMap() {
   }
 
   def calcOrientationSaliencyMap(src: Image): (Image, Image, Image, Image) = {
+    import scala.concurrent.{Future, Await}
+    import scala.concurrent.duration.FiniteDuration
+    implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
     val gaborFilter0 = new GaborFilter(11, 1.5, 1.2, 3, 0, 0)
     val gaborFilter45 = new GaborFilter(11, 1.5, 1.2, 3, 0, 45)
     val gaborFilter90 = new GaborFilter(11, 1.5, 1.2, 3, 0, 90)
     val gaborFilter135 = new GaborFilter(11, 1.5, 1.2, 3, 0, 135)
 
-    val gaborFilterdImage0: Image = gaborFilter0.filtering(src).normalize()
-    val gaborFilterdImage45: Image = gaborFilter45.filtering(src)
-    val gaborFilterdImage90: Image = gaborFilter90.filtering(src)
-    val gaborFilterdImage135: Image = gaborFilter135.filtering(src)
+    val gaborFilterdImage0: Future[Image] = Future { gaborFilter0.filtering(src).normalize() }
+    val gaborFilterdImage45: Future[Image] = Future{ gaborFilter45.filtering(src) }
+    val gaborFilterdImage90: Future[Image] = Future { gaborFilter90.filtering(src) }
+    val gaborFilterdImage135: Future[Image] = Future { gaborFilter135.filtering(src)}
 
-    val pyramid0 = makePyramid(gaborFilterdImage0)
-    val pyramid45 = makePyramid(gaborFilterdImage45)
-    val pyramid90 = makePyramid(gaborFilterdImage90)
-    val pyramid135 = makePyramid(gaborFilterdImage135)
+    val pyramid0 = gaborFilterdImage0.map(makePyramid(_))
+    val pyramid45 = gaborFilterdImage45.map(makePyramid(_))
+    val pyramid90 = gaborFilterdImage90.map(makePyramid(_))
+    val pyramid135 = gaborFilterdImage135.map(makePyramid(_))
 
-    val map0 =
+    val map0 = pyramid0.map(pyramid0 =>
       ((pyramid0(0) - pyramid0(1)))
         .+((pyramid0(0) - pyramid0(2)))
         .+((pyramid0(1) - pyramid0(2)))
         .+((pyramid0(2) - pyramid0(3)))
+    )
 
-    val map45 =
+    val map45 = pyramid45.map(pyramid45 =>
       ((pyramid45(0) - pyramid45(1)))
         .+((pyramid45(0) - pyramid45(2)))
         .+((pyramid45(1) - pyramid45(2)))
         .+((pyramid45(2) - pyramid45(3)))
+    )
 
-    val map90 =
+    val map90 = pyramid90.map(pyramid90 =>
       ((pyramid90(0) - pyramid90(1)))
         .+((pyramid90(0) - pyramid90(2)))
         .+((pyramid90(1) - pyramid90(2)))
         .+((pyramid90(2) - pyramid90(3)))
+    )
 
-    val map135 =
+    val map135 = pyramid135.map(pyramid135 =>
       ((pyramid135(0) - pyramid135(1)))
         .+((pyramid135(0) - pyramid135(2)))
         .+((pyramid135(1) - pyramid135(2)))
         .+((pyramid135(2) - pyramid135(3)))
+    )
 
-    (map0, map45, map90, map135)
+    val result = Await.result(Future.sequence(Seq(map0, map45, map90, map135)), FiniteDuration(30, "seconds"))
+    //(map0, map45, map90, map135)
+    (result(0), result(1), result(2), result(3))
   }
 
   override def saliencyMap(orig: Image): Image = {


### PR DESCRIPTION
画像処理が遅いという話を[Twitterでみかけた](https://twitter.com/NashiUsaBoy/status/1713561087617171551)のと、ScalaFXが楽しそうだったのでコードを眺めてみました。ついでに、こうすれば速くなりそうみたいなのを紹介します(お節介ですが・・・)。けっこう速くなります。 🙏🏻 

- `List`を避ける
  - 教科書的にはScalaのコレクションとして`List`が紹介されがちですが、`List`はその構造からランダムアクセスに非常に弱いです(アクセスに線形時間がかかります)。
  - 実務上では「リストっぽいものが必要」なときには`Seq`がもっともよく使われます。とりあえず`Seq`にしておくといいです。[`Seq`のデフォルトの実装は`Vector`](https://docs.scala-lang.org/overviews/collections-2.13/overview.html)なので、大抵の用途ではこれで十分です。
- ループ中で固定値を作ることを避ける
  - ループ内で`Range`を作っていると地味にパフォーマンスに影響することがあります。共通化して切り出すとよいです。
- 頻繁にランダムアクセスされる箇所に`ArraySeq`を使う
  - `ArraySeq`は`Seq`の一種で、中身が`Array`になっている版です。`Vector`よりも薄い構造であり、完全に定数でランダムアクセスできます。ただし要素の追加のためには`Array`を全て作り直す必要がある(`Vector`ではそこまでする必要がない)というトレードオフがあります。
- 非同期実行できそうな箇所は非同期にする
  - [`Future`](https://scala-text.github.io/scala_text/future-and-promise.html)を使うとどこか別のスレッドに処理を放り投げられます。ただしスレッド生成のコストを払う必要があるので、有効なのは高頻度で呼ばれない箇所に限られます。
  - ガボールフィルタをいくつか同時に適用する箇所でこれに当てはまったため`Future`を利用しました。
  - `Future.sequence`を使うといくつかの`Future`が全て揃うまで待機し、それらをまとめて1つの`Future`にできます。
  - `Await.result`を使うと`Future`が完了するまで待機し、その中身を返します。

より高速にするには、高速計算が必要な箇所を割り切ってmutableに書くとか(一般に、メモリ確保が一番遅いです)、`Pixel`クラスから`x, y`情報を剥ぎ取って軽量化するといった手法がありそうです。

いきなりやってきてすみません！